### PR TITLE
Fix "Open next 10": stop marking blocked tabs as done

### DIFF
--- a/index.html
+++ b/index.html
@@ -673,9 +673,14 @@ document.getElementById("batch-btn").addEventListener("click", () => {
   }
   if (!undone.length) { alert("All tracks are done!"); return; }
 
+  let blocked = false;
   for (const i of undone) {
     const [artist, title] = currentTracks[i];
-    window.open(searchUrl(artist, title), "_blank");
+    const win = window.open(searchUrl(artist, title), "_blank");
+    // Browsers permit only the first window.open() per click unless pop-ups are
+    // allowed for the site. A null/undefined handle means the tab was blocked —
+    // stop here and don't mark tracks done that never actually opened.
+    if (!win) { blocked = true; break; }
     if (!currentSaved[i]) {
       currentSaved[i] = true;
       const doneBtn = document.querySelector(`.done-btn[data-i="${i}"]`);
@@ -692,6 +697,9 @@ document.getElementById("batch-btn").addEventListener("click", () => {
   const batchBtn = document.getElementById("batch-btn");
   if (remaining <= 0) { batchBtn.textContent = "All done!"; batchBtn.disabled = true; }
   else { batchBtn.textContent = "Open next " + Math.min(remaining, 10); batchBtn.disabled = false; }
+  if (blocked) {
+    alert("Your browser blocked the extra tabs. Allow pop-ups for this site, then click “Open next” again to open the rest.");
+  }
 });
 
 // Detect a single-line YouTube playlist URL (kept as a silent fallback if a


### PR DESCRIPTION
## Problem

Clicking **Open next 10** opens only **1 tab** but marks all 10 tracks as done.

Two causes in the `batch-btn` handler (`index.html`):
1. Browsers honor only the **first** `window.open()` per click unless pop-ups are allowed for the site — the 2nd–10th calls are silently blocked.
2. The loop marked `currentSaved[i] = true` for every track regardless of whether its tab actually opened, so the UI lied about what happened.

## Fix

- Capture `window.open()`'s return value. A null/undefined handle means the tab was blocked → break out of the loop and **only mark tracks that actually opened**.
- Show a one-time `alert()` when a tab was blocked, telling the user to allow pop-ups and click **Open next** again.

The first track always opens (user-gesture), so the worst case is now: 1 tab opens, 1 track marked done, clear message about how to get the rest — instead of 1 tab + 10 falsely marked.

## Testing

Manual: with pop-ups blocked, click **Open next 10** → 1 tab opens, 1 track marked, alert shown. Allow pop-ups, click again → remaining tabs open and mark correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)